### PR TITLE
Allow versions of `six` >= 1.9.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
         'taking advantage of Python\'s named capture groups.'
     ),
     install_requires=[
-        "six==1.9.0",
+        "six>=1.9.0",
     ],
     packages=[],
     py_modules=['repath'],


### PR DESCRIPTION
Hard-pinning this requirement means that apps using the library can't install any other version of six. It doesn't look like there's a reason to downpin this, so this should be safe.